### PR TITLE
Added Fiddler Warning and Ending

### DIFF
--- a/Dot 3 Github.py
+++ b/Dot 3 Github.py
@@ -468,7 +468,8 @@ async def startextra(interaction: nextcord.Interaction):
 
         # Notify user after 40 minutes
         await asyncio.sleep(RE_RACK_TIMER_DURATION)
-        await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
+        if str(user.id) in active_storytellers:
+            await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
         # Notify user after 2hr if still storytelling
         await asyncio.sleep(FIDDLER_WARNING_DURATION)
         if str(user.id) in active_storytellers:
@@ -568,7 +569,8 @@ async def start_user(interaction, user):
 
     # Notify user after 40 minutes
     await asyncio.sleep(RE_RACK_TIMER_DURATION)
-    await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
+    if str(user.id) in active_storytellers:
+        await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
     # Notify user after 2hrs if still storytelling
     await asyncio.sleep(FIDDLER_WARNING_DURATION)
     if str(user.id) in active_storytellers:

--- a/Dot 3 Github.py
+++ b/Dot 3 Github.py
@@ -28,6 +28,8 @@ PICKUP_COOLDOWN_DURATION = 144000
 ANY_COOLDOWN_DURATION = 144000
 REMOVECOOLDOWN_COOLDOWN_DURATION = 5184000 # 60 Days
 RE_RACK_TIMER_DURATION = 2400  # 40 minutes
+FIDDLER_WARNING_DURATION = 4800  # 80 minutes after rerack (2hrs after game start)
+FIDDLER_ENDING_DURATION = 3600  # 60 minutes after fiddler warning (3hrs after game start)
 
 # Define cooldown duration for leaving the queue (1 hour in seconds)
 LEAVE_COOLDOWN_DURATION = 3600
@@ -388,7 +390,7 @@ async def removecooldown(interaction: nextcord.Interaction):
     player = interaction.user
 
     if cooldowns[str(player.id)]["removeCooldown_Cooldown"] > current_time:
-        await interaction.response.send_message(f"{player.display_name} cannot remove their cooldown until <t:{cooldowns[str(player.id)]["removeCooldown_Cooldown"]}>.")
+        await interaction.response.send_message(f"{player.display_name} cannot remove their cooldown until <t:{cooldowns[str(player.id)]['removeCooldown_Cooldown']}>.")
     elif str(player.id) in cooldowns:
         cooldowns[str(player.id)]["Cooldown"] = current_time
         cooldowns[str(player.id)]["removeCooldown_Cooldown"] = current_time + REMOVECOOLDOWN_COOLDOWN_DURATION
@@ -467,6 +469,15 @@ async def startextra(interaction: nextcord.Interaction):
         # Notify user after 40 minutes
         await asyncio.sleep(RE_RACK_TIMER_DURATION)
         await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
+        # Notify user after 2hr if still storytelling
+        await asyncio.sleep(FIDDLER_WARNING_DURATION)
+        if str(user.id) in active_storytellers:
+            await interaction.channel.send(f"{user.mention}, your game has gone on for 2 hours. Direct players to DM you if they need the game to be over. If the majority of players do so, you must end the game with the Fiddler.")
+        # Notify user after 3hrs if still storytelling
+        await asyncio.sleep(FIDDLER_ENDING_DURATION)
+        if str(user.id) in active_storytellers:
+            await interaction.channel.send(f"{user.mention}, your game has gone on for 3 hours. You are now required to end the game with the Fiddler.")
+        
     else:
         await interaction.response.send_message("You are not eligible to start extra.")
 
@@ -558,6 +569,15 @@ async def start_user(interaction, user):
     # Notify user after 40 minutes
     await asyncio.sleep(RE_RACK_TIMER_DURATION)
     await interaction.channel.send(f"{user.mention}, the Re-rack timer has expired.")
+    # Notify user after 2hrs if still storytelling
+    await asyncio.sleep(FIDDLER_WARNING_DURATION)
+    if str(user.id) in active_storytellers:
+        await interaction.channel.send(f"{user.mention}, your game has gone on for 2 hours. Direct players to DM you if they need the game to be over. If the majority of players do so, you must end the game with the Fiddler.")
+    # Notify user after 3hrs if still storytelling
+    await asyncio.sleep(FIDDLER_ENDING_DURATION)
+    if str(user.id) in active_storytellers:
+        await interaction.channel.send(f"{user.mention}, your game has gone on for 3 hours. You are now required to end the game with the Fiddler.")
+    
 
 @bot.slash_command(name="start", description="Start a game if you're next to ST")
 async def start(interaction: nextcord.Interaction):


### PR DESCRIPTION
After 2 hours of the game the bot will send a request in chat for a fiddler to be implemented. After 3 hours of the game the bot will remind the ST that they have to implement a fiddler. These messages only send if the ST is active. Additionally made the re-rack timer only send if the ST it is for is active. (also switched a " pair for a ' pair on L393 because my bot didnt like it)