### PR TITLE
townsquare_spy: Understand self-naming messages.

### DIFF
--- a/townsquare_spy/spy.py
+++ b/townsquare_spy/spy.py
@@ -84,6 +84,7 @@ def townsquare_handler(name):
 @townsquare_handler('ping')
 @townsquare_handler('votingSpeed')
 @townsquare_handler('isVoteWatchingAllowed')  # clocktower.live extension
+@townsquare_handler('allowSelfNaming')        # clocktower.live extension
 def ignore_message(*args):
     """
     Ignore all arguments for the received message.
@@ -284,6 +285,14 @@ def change_pronouns(session, pronoun_info):
         session.log(f'{player_name(player.name)} changed their pronouns to {player_pronouns(player.pronouns)}.')
     else:
         session.log(f'{player_name(player.name)} cleared their pronouns.')
+
+# clocktower.live extension
+@townsquare_handler('name')
+def change_name(session, name_info):
+    index, new_name = name_info
+    player = session.players[index]
+    old_name, player.name = player.name, new_name
+    session.log(f'{player_name(old_name)} changed their name to {player_name(new_name)}.')
 
 @townsquare_handler('nomination')
 def nominate(session, nom = None):

--- a/townsquare_spy/spy_test.py
+++ b/townsquare_spy/spy_test.py
@@ -258,10 +258,13 @@ def test_rename_player():
     output.clear()
     receive(session, ["player", dict(index=2, property="name", value="Charles")])
     receive(session, ["pronouns", [2, "he/him"]])
-    assert session.players[2].name == "Charles"
+    receive(session, ["allowSelfNaming", True])
+    receive(session, ["name", [2, "Charlie"]])
+    assert session.players[2].name == "Charlie"
     assert session.players[2].pronouns == "he/him"
     assert any_line_matches(output, r'Charlie.*renamed.*Charles')
     assert any_line_matches(output, r'Charles.*he/him')
+    assert any_line_matches(output, r'Charles.*Charlie')
 
 def test_death_resurrection():
     session, output = simulated_session()


### PR DESCRIPTION
These messages were causing townsquare_spy to crash, and since this feature has become popular, this limited visibility.