### PR TITLE
Fix Beginner and Pickup queues sometimes swapping when the queue is split

### DIFF
--- a/Dot 3 Github.py
+++ b/Dot 3 Github.py
@@ -550,6 +550,13 @@ async def setqueue(interaction: nextcord.Interaction, queue_type: str = nextcord
     await interaction.response.send_message(f"The queue for {queue_type} has been updated with the mentioned players.")
 
 async def start_user(interaction, user):
+    if queue[str(user.id)]["QueueType"] == "Any":
+        channel = interaction.channel_id
+        if channel == BEGINNER_CHANNEL_ID:
+            queue[str(user.id)]["QueueType"] = "Beginner"
+        else:
+            queue[str(user.id)]["QueueType"] = "Pickup"
+    
     add_active_storyteller(user, queue[str(user.id)]["QueueType"])
     await remove_queue(user.id)
     await interaction.response.send_message(f"{user.display_name} is now active.", ephemeral=False)
@@ -588,8 +595,6 @@ async def check_queue():
                 user = await bot.fetch_user(user_id)
                 channel = bot.get_channel(MERGED_CHANNEL_ID)
                 initial_merged_state = MERGED
-
-                queue[str(user.id)]["QueueType"] = "Pickup"
 
                 embed = nextcord.Embed(title=f"Game Notification for {queue[str(user_id)]['QueueType']} Queue", description=f"{user.mention}, it's your turn!")
                 embed.set_thumbnail(url=user.display_avatar.url)
@@ -654,8 +659,6 @@ async def check_queue():
                     channel = bot.get_channel(BEGINNER_CHANNEL_ID)
                     initial_merged_state = MERGED
 
-                    queue[str(user.id)]["QueueType"] = "Beginner"
-
                     embed = nextcord.Embed(title=f"Game Notification for {queue[str(user_id)]['QueueType']} Queue", description=f"{user.mention}, it's your turn!")
                     embed.set_thumbnail(url=user.display_avatar.url)
                     timeout_timestamp = int(time.time()) + TIMEOUT_TIMER
@@ -719,8 +722,6 @@ async def check_queue():
                     user = await bot.fetch_user(user_id)
                     channel = bot.get_channel(PICKUP_CHANNEL_ID)
                     initial_merged_state = MERGED
-
-                    queue[str(user.id)]["QueueType"] = "Pickup"
 
                     embed = nextcord.Embed(title=f"Game Notification for {queue[str(user_id)]['QueueType']} Queue", description=f"{user.mention}, it's your turn!")
                     embed.set_thumbnail(url=user.display_avatar.url)


### PR DESCRIPTION
Fix Beginner and Pickup queues sometimes swapping when the queue is split

# Background

The Beginner and Pickup queues had the potential to swap channels when the queue was split. My belief is that this was caused by the bot automatically assigning the next ST to the Pickup queue when they start while the queues are merged, regardless of the queue they joined. As a direct result of this, when the queues were split the next Beginner ST would be called to run, even if the current game was running in the Beginner channels. Depending on how the players/STs reacted, this could then mean that the Beginner ST that was called would run their Beginner game in the Pickup channels.

When an ST finishes their game and uses the `/finish` command, the Beginner or Pickup channel IDs are set to the ID of the channel in which the command was run. This means that if a Beginner ST runs `/finish` in the Pickup game channels, the Beginner channel ID is set to be the ID of the Pickup channel. When the Pickup ST then subsequently uses `/finish` in the Beginner channel, the Pickup channel ID is also reassigned. At this point, the channels have both swapped and the queues appear to be running "backwards".

# Changes

This pull request removes the hard-coded assignment of the `QueueType` that is applied when an ST is called to start, which prevents the next ST from being forced into the Pickup queue when the queues are merged. Because most of the logic in Dot bot does not account for the Any queue, and removing the forced assignment can result in STs remaining in the Any queue, additional logic was added to `start_user`. This logic checks if the user is in the Any queue when they start, and sets their `QueueType` to be Beginner or Pickup depending on which channel they run the `/start` command in.

These changes should result in a more accurate determination of the queue for which an ST is currently running their game.

# Limitations

If a user runs `/start` in the Pickup channel while merged, but then decides to run their game in the Beginner channels, a split that occurs mid-game would call for the next Beginner ST, and when the ST uses `/finish` they would set the Pickup channel to be the Beginner channel.

Further changes may be able to mitigate this vulnerability also.